### PR TITLE
Retain logger configuration

### DIFF
--- a/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/JDKXRLogger.java
+++ b/flying-saucer-core/src/main/java/org/xhtmlrenderer/util/JDKXRLogger.java
@@ -179,6 +179,9 @@ public class JDKXRLogger implements XRLogger {
         }
     }
 
+    /* HACK: if loggers are not sequestered as strong references, they get garbage collected, losing their configuration */
+    public static List<Logger> savedLoggers = null;
+
     /**
      * Returns a List of all Logger instances used by Flying Saucer from the JDK LogManager; these will
      * be automatically created if they aren't already available.
@@ -191,6 +194,7 @@ public class JDKXRLogger implements XRLogger {
             final String ln = (String) it.next();
             loggers.add(Logger.getLogger(ln));
         }
+        savedLoggers = loggers;
         return loggers;
     }
 


### PR DESCRIPTION
by saving a strong reference to them.

I was encountering strange behaviour with the loggers. They start off by respecting the logger configuration, but after some time revert back to default behaviour.

After spending a day chasing this, I realized that the Java platform doesn't keep strong references to Loggers (by design). So after a GC cycle, the loggers get destroyed and get re-created upon the next log call. The newly created loggers don't have any configuration applied to them.

This PR is just a quick hack. A long term solution might be to use a logging framework such as `slf4j` which probably will take care of this. I see that you have already begun some work there.
