### PR TITLE
Log the message of a throwable (exception)

### DIFF
--- a/flying-saucer-core/src/main/resources/resources/conf/xhtmlrenderer.conf
+++ b/flying-saucer-core/src/main/resources/resources/conf/xhtmlrenderer.conf
@@ -40,7 +40,7 @@ xr.test.files.hamlet = /demos/browser/xhtml/hamlet.xhtml
 #
 # Two formats, for with and without exception
 xr.simple-log-format = {1} {2}:: {5}
-xr.simple-log-format-throwable = {1} {2}:: {5}
+xr.simple-log-format-throwable = {1} {2}:: {5} :: {7}
 
 
 # Values used for testing Configuration, do not modify


### PR DESCRIPTION
Currently, an exception when logged doesn't show any details about the exception.

At least the exception's message should be shown, and this PR does that.

Logging the stack trace might also be a good idea to consider.
